### PR TITLE
build 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # skbase-feedstock
 A conda recipe for skbase.
+
+Skbase provides base classes for creating scikit-learn-like parametric objects, along with tools to make it easier to build your own packages that follow these design patterns.
+
+# Home:
+https://github.com/sktime/skbase
+
+# Upstream license:
+BSD-3-Clause
+
+# Feedstock license:
+BSD-3-Clause
+
+# Docs:
+https://github.com/sktime/skbase
+
+# Dev:
+https://github.com/sktime/skbase

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "sktime" %}
+{% set version = "0.6.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/sktime/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 8fa46a28fe6925eae892206a93d77dc75601de5dd8ab59d6f24fca3ea069c360
+
+build:
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  number: 0
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - wheel
+    - toml
+    - build
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - skbase
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/sktime/skbase
+  license: BSD-3-Clause
+  license_file: LICENSE
+  license_family: BSD
+  summary: Base classes for sklearn-like parametric objects
+  description: |
+    skbase provides base classes for creating scikit-learn-like parametric objects, along with tools to make it easier
+    to build your own packages that follow these design patterns.
+  doc_url: https://github.com/sktime/skbase
+  dev_url: https://github.com/sktime/skbase
+
+extra:
+  recipe-maintainers:
+    - boldorider4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,9 +17,9 @@ requirements:
     - python
     - setuptools
     - wheel
-    - toml
-    - build
     - pip
+    - toml 0.10.2
+    - build 0.10.0
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ requirements:
     - wheel
     - pip
     - toml
-    - build 0.10.0
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "sktime" %}
+{% set name = "skbase" %}
 {% set version = "0.6.1" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,12 +24,19 @@ requirements:
     - python
 
 test:
+  source_files:
+    - skbase/tests
   imports:
     - skbase
   commands:
     - pip check
+    - pytest skbase/tests
   requires:
     - pip
+    - pytest
+    - numpy
+    - scipy
+    - pandas
 
 about:
   home: https://github.com/sktime/skbase

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - setuptools
     - wheel
     - pip
-    - toml 0.10.2
+    - toml
     - build 0.10.0
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "skbase" %}
-{% set version = "0.6.1" %}
+{% set version = "0.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,10 @@ package:
 
 source:
   url: https://github.com/sktime/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 6035abd254fe7da82afb1b038e78dcc056f4fd62ac5d98a7a8c708c85a21b857
-
+  sha256: 085a97b1a5acb649a836b88ee5c30c8b9a8258baaee86c6ac73d366c2bae480f
 build:
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/sktime/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 8fa46a28fe6925eae892206a93d77dc75601de5dd8ab59d6f24fca3ea069c360
+  sha256: 6035abd254fe7da82afb1b038e78dcc056f4fd62ac5d98a7a8c708c85a21b857
 
 build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv


### PR DESCRIPTION
* [PKG-3452] ❄️ 
* dependency for [PKG-3450] ❄️ 
* [Upstream requirements](https://github.com/sktime/skbase/blob/v0.6.0/pyproject.toml)

Notes:
- `0.6.1`, which on this day is the latest version, cannot be built because of a broken project configuration
- the upstream tarball has been taken from the GH since PyPi is out of date and this is a dependency for `sktime`, which is developed by the same developer on GH.

[PKG-3452]: https://anaconda.atlassian.net/browse/PKG-3452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-3450]: https://anaconda.atlassian.net/browse/PKG-3450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ